### PR TITLE
Removes non standard git command

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -14,8 +14,8 @@ rm Gemfile
 cp $SCRIPT_PATH"/files/Gemfile" .
 bundle install --without production
 git init
-git ignore tmp/**.*
-git ignore log/**.*
+echo 'tmp/**.*' >> .gitignore
+echo 'log/**.*' >> .gitignore
 
 cat $SCRIPT_PATH"/files/config/db_config" > config/database.yml
 


### PR DESCRIPTION
`git ignore` is not a standard git command [(setup.bash#L17-18)](https://github.com/Albin-trialbee/rails-setup/blob/master/setup.bash#L17-18)

Replaced:

``` bash
echo 'tmp/**.*' >> .gitignore
echo 'log/**.*' >> .gitignore
```
